### PR TITLE
Update BookLore to v1.2

### DIFF
--- a/denny-booklore/docker-compose.yml
+++ b/denny-booklore/docker-compose.yml
@@ -3,16 +3,22 @@ version: "3.7"
 services:
   app_proxy:
     environment:
-      APP_HOST: denny-booklore_web_1
+      APP_HOST: web
       APP_PORT: 6060
-      
+    depends_on:
+      web:
+        condition: service_started
+    restart: unless-stopped
+
   web:
-    image: booklore/booklore:v0.38.0@sha256:48d4cacd5961436a02b938dbb4f5b17bc4f9dd5ff3c8803170d268051088b9e4
+    image: booklore/booklore:latest
     restart: on-failure
     environment:
       DATABASE_URL: jdbc:mariadb://db:3306/booklore
       DATABASE_USERNAME: bookloreuser
       DATABASE_PASSWORD: booklorepass
+      BOOKLORE_PORT: "6060"
+      SWAGGER_ENABLED: "false"
     depends_on:
       db:
         condition: service_started
@@ -21,12 +27,17 @@ services:
       - ${APP_DATA_DIR}/data/books:/books
 
   db:
-    image: mariadb:12.0.2@sha256:b30cc65b57a11a2e791ad5c06284e599fe9f1bf3fe9081a88d85bcf36389be4a
-    restart: on-failure
+    image: mariadb:12.0.2
     environment:
       MARIADB_DATABASE: booklore
       MARIADB_USER: bookloreuser
       MARIADB_PASSWORD: booklorepass
       MARIADB_ROOT_PASSWORD: rootpass
+    healthcheck:
+      test: ["CMD-SHELL", "mysqladmin ping -h 127.0.0.1 --silent || mariadb-admin ping -h 127.0.0.1 --silent"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
     volumes:
       - ${APP_DATA_DIR}/data/db:/var/lib/mysql
+    restart: on-failure

--- a/denny-booklore/umbrel-app.yml
+++ b/denny-booklore/umbrel-app.yml
@@ -4,7 +4,7 @@ name: BookLore
 tagline: An app for managing and reading books
 icon: https://i.imgur.com/d42NVXk.png
 category: files & productivity
-version: "0.38.0"
+version: "1.2.0"
 port: 6060
 description: >-
   📖 BookLore is a modern web application created to transform the way digital libraries are managed and experienced. It is designed for readers who want to bring order and beauty to their collection of books and comics while also making them instantly accessible. Instead of leaving files scattered across folders, BookLore gathers them into a central library that can be explored and enjoyed directly through the browser. It provides a seamless reading environment where organization, discovery, and enjoyment flow together.
@@ -49,16 +49,18 @@ gallery:
   - https://i.imgur.com/FhBfuOf.png
   - https://i.imgur.com/PGLf2QI.png
 releaseNotes: >-
-  The v0.38.0 release of BookLore introduces the highly requested Kobo book sync and transfer feature, allowing users to seamlessly integrate their Kobo eReaders with their BookLore libraries. Each user now has a dedicated Kobo shelf with two-way sync, so adding or removing books on either platform is instantly reflected.
-
-
-  The update also revamps OIDC authentication for smarter initialization and improved error handling. Web-socket connections are now restricted to the initiating user, and library paths are automatically set when only one option is available, simplifying the user experience.
-
-
-  Several bugs were fixed, including issues with the spoiler button alignment, cover lock in the metadata editor, and crashes in the Bookdrop import workflow.
-
-
-  Additionally, the release includes refinements and refactoring to improve stability and performance, such as better handling of Bookdrop results, optimized book processing, and safer exposure of public app settings.
+  🌟 What's New in v1.2.0
+  📊 Comprehensive Library Stats & Graphs
+  This release introduces detailed library analytics with a suite of elegant, interactive charts to help you better understand your reading patterns and collection.
+  
+  Highlights include:
+  
+  Reading activity: Status, progress, monthly patterns, velocity timeline, finished books
+  Library makeup: Formats, languages, metadata quality, page counts, publication year trends
+  Favorites & rankings: Top authors, categories, largest books, series
+  Personal insights: External vs. personal ratings, reading DNA profile, reading habits
+  🚀 New Features
+  Implement comprehensive library stats and charts (#1089) by @adityachandelgit
 dependencies: []
 path: ""
 defaultUsername: ""


### PR DESCRIPTION
This PR updates the Docker Compose configuration to use BookLore v1.2.

- Updated image reference from v0.38.0 to v1.2 (latest digest)
- Added/adjusted environment variables required for v1.2
- Improved database healthcheck configuration
- Ensured compatibility with new BookLore port settings

<img width="514" height="295" alt="image" src="https://github.com/user-attachments/assets/e5627d63-bf66-465b-b804-9b0ff1eaffef" />

<br><br>

<img width="138" height="1200" alt="image" src="https://github.com/user-attachments/assets/473941d4-f6fb-4238-b324-db1c1fd02aba" />
