### PR TITLE
updates wally to 1.6

### DIFF
--- a/denny-wally/docker-compose.yml
+++ b/denny-wally/docker-compose.yml
@@ -7,9 +7,9 @@ services:
       APP_PORT: 80
 
   web:
-    image: poliuscorp/wally:1.1@sha256:379e33d295e4b44e971135a5af8955db26fb878b734edbdc02e2381acdc90b83
+    image: poliuscorp/wally:1.6@sha256:76b8f997a444236d00007e2f2c291567e86beb2c2bce6accfc87760ffb90eebd
     restart: on-failure
     volumes:
       - ${APP_DATA_DIR}/data:/wally/data
     environment:
-      DEMO: "true"
+      DEMO: "false"

--- a/denny-wally/umbrel-app.yml
+++ b/denny-wally/umbrel-app.yml
@@ -4,7 +4,7 @@ name: Wally
 tagline: A lightweight expense tracker
 icon: https://raw.githubusercontent.com/dennysubke/dennys-umbrel-app-gallery/main/denny-wally/logo.png
 category: finance
-version: "1.1"
+version: "1.6"
 port: 3811
 description: >-
   👛 Wally is a personal finance management application designed to help users take control of their money and gain a clear understanding of their financial situation. It provides a platform where users can easily record their income and expenses, ensuring that every transaction is accounted for. By keeping a detailed history of financial activity, Wally enables users to track their spending patterns over time and identify areas where they can save or adjust their budget.
@@ -26,7 +26,7 @@ gallery:
   - https://raw.githubusercontent.com/dennysubke/dennys-umbrel-app-gallery/main/denny-wally/3.jpg
   - https://raw.githubusercontent.com/dennysubke/dennys-umbrel-app-gallery/main/denny-wally/4.jpg
 releaseNotes: >-
-  This update introduces a new optional HTTPS environment variable that restricts authenticated API access to secure connections only, preventing authentication tokens from being sent over HTTP. Login sessions have also been improved with an expiration time for cookies, allowing sessions to persist even after closing the browser.
+  This update introduces improved footer layout (Income, Expenses, Balance) for better usability on mobile devices.
 dependencies: []
 path: ""
 defaultUsername: ""


### PR DESCRIPTION
Updated Wally to `1.6`, current version is `1.1`.
Also removed the `DEMO="true"` which caused the app to come full of placeholder data.