### PR TITLE
Add pre-install script for Docker swarm setup

### DIFF
--- a/denny-dokploy/hooks/pre-install
+++ b/denny-dokploy/hooks/pre-install
@@ -1,0 +1,7 @@
+#!/bin/bash
+  
+docker swarm init
+echo "Swarm initialized"
+
+docker network create --driver overlay dokploy-network
+echo "Network created"

--- a/denny-dokploy/hooks/pre-install
+++ b/denny-dokploy/hooks/pre-install
@@ -3,5 +3,5 @@
 docker swarm init
 echo "Swarm initialized"
 
-docker network create --driver overlay dokploy-network
+docker network create --driver overlay --attachable dokploy-network
 echo "Network created"


### PR DESCRIPTION
This pull request adds a new pre-installation hook script to automate Docker Swarm initialization and network setup. The script ensures that the required Docker Swarm environment and overlay network are ready before proceeding with further deployment steps.

Deployment automation:

* Added `denny-dokploy/hooks/pre-install` script to initialize Docker Swarm and create an overlay network named `dokploy-network`.

reference: [dokploy manual installation](https://docs.dokploy.com/docs/core/manual-installation#installation-script:~:text=docker%20swarm%20init%20%2D%2Dadvertise,%2D%2Dattachable%20dokploy%2Dnetwork)