### PR TITLE
Update Crafty Controller to version 4.9.0

### DIFF
--- a/denny-crafty/docker-compose.yml
+++ b/denny-crafty/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.7'
 services:
   crafty:
     container_name: crafty_container
-    image: registry.gitlab.com/crafty-controller/crafty-4:4.9.0sha@256:ea04b6c57716c48f80039f7837417bde722b8fecaba2826846076f77675ab395
+    image: registry.gitlab.com/crafty-controller/crafty-4:4.9.0@sha256:ea04b6c57716c48f80039f7837417bde722b8fecaba2826846076f77675ab395
     ports:
       - "18443:8443" 
       - "18123:8123" 
@@ -16,6 +16,7 @@ services:
       - ${APP_DATA_DIR}/data/config:/crafty/app/config
       - ${APP_DATA_DIR}/data/import:/crafty/import
     restart: on-failure
+
 
 
 

--- a/denny-crafty/docker-compose.yml
+++ b/denny-crafty/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.7'
 services:
   crafty:
     container_name: crafty_container
-    image: registry.gitlab.com/crafty-controller/crafty-4:4.9.0sha256:ea04b6c57716c48f80039f7837417bde722b8fecaba2826846076f77675ab395
+    image: registry.gitlab.com/crafty-controller/crafty-4:4.9.0sha@256:ea04b6c57716c48f80039f7837417bde722b8fecaba2826846076f77675ab395
     ports:
       - "18443:8443" 
       - "18123:8123" 
@@ -16,5 +16,6 @@ services:
       - ${APP_DATA_DIR}/data/config:/crafty/app/config
       - ${APP_DATA_DIR}/data/import:/crafty/import
     restart: on-failure
+
 
 

--- a/denny-crafty/docker-compose.yml
+++ b/denny-crafty/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.7'
 services:
   crafty:
     container_name: crafty_container
-    image: registry.gitlab.com/crafty-controller/crafty-4:4.5.4@sha256:0f2dc8cf1d490804b748510b27ae45b8deffda28c201a6b416dc6e9916ce3f29
+    image: registry.gitlab.com/crafty-controller/crafty-4:4.9.0sha256:ea04b6c57716c48f80039f7837417bde722b8fecaba2826846076f77675ab395
     ports:
       - "18443:8443" 
       - "18123:8123" 
@@ -16,4 +16,5 @@ services:
       - ${APP_DATA_DIR}/data/config:/crafty/app/config
       - ${APP_DATA_DIR}/data/import:/crafty/import
     restart: on-failure
+
 

--- a/denny-crafty/umbrel-app.yml
+++ b/denny-crafty/umbrel-app.yml
@@ -4,7 +4,7 @@ name: Crafty Controller
 tagline: An intuitive way to automate and manage your Minecraft server with ease
 icon: https://raw.githubusercontent.com/dennysubke/dennys-umbrel-app-gallery/main/denny-crafty/logo.png
 category: gaming
-version: "4.5.4"
+version: "4.9.0"
 port: 18443
 description: >-
   ⛏️ Crafty Controller is an open-source, web-based interface designed to manage and control Crafty Bots, which are used for automating and managing Minecraft servers. Crafty itself is a bot framework that allows administrators to automate various tasks on Minecraft servers, from running tests to managing in-game events, controlling server settings, and much more. Crafty Controller provides a centralized platform where administrators can monitor and control these bots from one place.
@@ -39,7 +39,7 @@ gallery:
   - https://raw.githubusercontent.com/dennysubke/dennys-umbrel-app-gallery/main/denny-crafty/4.jpg
   - https://raw.githubusercontent.com/dennysubke/dennys-umbrel-app-gallery/main/denny-crafty/5.jpg
 releaseNotes: >-
-  Version 4.5.4 fixes bugs by refactoring the upload process to ensure asynchronous file operations. It also removes all third-party font requests.
+  Version 4.9.0 added support for Hytale servers.
 dependencies:
 path: "https://umbrel.local:18443"
 defaultUsername: "admin"


### PR DESCRIPTION
I've updated Crafty Controller to 4.9.0 (current is 4.5.4)
This was really needed as some bugs were patched, they added passkey auth, and they also added support for Hytale server hosting.