### PR TITLE
Update app image version and add PROXY_AUTH_ADD

### DIFF
--- a/denny-spoolman/docker-compose.yml
+++ b/denny-spoolman/docker-compose.yml
@@ -5,9 +5,9 @@ services:
     environment:
       APP_HOST: denny-spoolman_web_1
       APP_PORT: 8000
-
+      PROXY_AUTH_ADD: false
   web:
-    image: ghcr.io/donkie/spoolman:0.22.1@sha256:238ea5bfb2eeda4436c39f54e73df5fef4ee904fb7c291617588b856786fe0ef
+    image: ghcr.io/donkie/spoolman:0.23.1@sha256:c798bcc19194949962044459e4b43c09d667d084ae9c2c2e0187a42c36d43d9e
     user: "0:0"
     environment:
       - TZ=UTC


### PR DESCRIPTION
Updates Spoolman to version 0.23.1 and disabled authentication on the application proxy so Moonraker can connect