### PR TITLE
Update Glances to 4.5.5

### DIFF
--- a/denny-glances/docker-compose.yml
+++ b/denny-glances/docker-compose.yml
@@ -6,7 +6,6 @@ services:
       APP_HOST: denny-glances_web_1
       APP_PORT: 61208
       PROXY_AUTH_ADD: 'false'
-    container_name: denny-glances-app_proxy-1
 
   web:
     image: nicolargo/glances:4.5.5@sha256:9ac5de7debffb1e5746654585daaf1d23179ea91fbdfd4c25a7a17945d9c74bf
@@ -23,4 +22,3 @@ services:
       timeout: 10s
       retries: 3
       start_period: 40s
-    container_name: denny-glances_web_1

--- a/denny-glances/docker-compose.yml
+++ b/denny-glances/docker-compose.yml
@@ -5,10 +5,11 @@ services:
     environment:
       APP_HOST: denny-glances_web_1
       APP_PORT: 61208
-      PROXY_AUTH_ADD: "false"
+      PROXY_AUTH_ADD: 'false'
+    container_name: denny-glances-app_proxy-1
 
   web:
-    image: nicolargo/glances:4.3.0.8@sha256:b701ae99ee6ea402f56a7a94f2f374c5cca896d6e4d0cd8506d41b4a1b5adfe3
+    image: nicolargo/glances:4.5.5@sha256:9ac5de7debffb1e5746654585daaf1d23179ea91fbdfd4c25a7a17945d9c74bf
     environment:
       - TZ=Europe/Berlin
       - GLANCES_OPT=-w
@@ -16,3 +17,10 @@ services:
     restart: on-failure
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
+    healthcheck:
+      test: ['CMD', 'curl', '-f', 'http://localhost:61208/api/4/status']
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+    container_name: denny-glances_web_1

--- a/denny-glances/umbrel-app.yml
+++ b/denny-glances/umbrel-app.yml
@@ -4,7 +4,7 @@ name: Glances
 tagline: An eye on your system
 icon: https://raw.githubusercontent.com/dennysubke/dennys-umbrel-app-gallery/main/denny-glances/logo.png
 category: networking
-version: "4.3.0.8"
+version: "4.5.5"
 port: 61208
 description: >-
   Glances is a versatile, open-source system monitoring tool designed to provide real-time insights into various aspects of your system's performance. Written in Python, it works across multiple platforms, including Linux, macOS, and Windows. The main purpose of Glances is to offer a quick, comprehensive overview of critical system metrics such as CPU, memory, disk, network, and process usage.
@@ -34,7 +34,13 @@ gallery:
   - https://raw.githubusercontent.com/dennysubke/dennys-umbrel-app-gallery/main/denny-glances/2.jpg
   - https://raw.githubusercontent.com/dennysubke/dennys-umbrel-app-gallery/main/denny-glances/3.jpg
 releaseNotes: >-
-  The WebUI display has been improved for low screen resolutions, the IP plugin issue with Netifaces2 has been fixed, and a message has been added to verify Netifaces2.
+  This update includes:
+    - Code refactoring: Simplified plugin code across start(), mem, connections, containers, amps, and exports for better maintainability
+    - New monitoring features: Added VM statistics support, InfluxDB 3 Core compatibility, and SQL/TimeScaleDB export options
+    - Web UI & API improvements: Added memory caching for API calls, improved documentation, and fixed time display in WebUI
+    - Security updates: Fixed multiple vulnerabilities and upgraded dependencies
+
+  Full release notes can be found at https://github.com/nicolargo/glances/releases
 dependencies:
 path: ""
 defaultUsername: ""


### PR DESCRIPTION
Updated Glances to 4.5.5 and added healthcheck (see [source](https://github.com/nicolargo/glances/blob/develop/docker-compose/docker-compose.yml)).

Tested on my Raspberry Pi 5 with Umbrel OS 1.5 and nettop with Umbrel OS 1.7.3.