### PR TITLE
Update Zipline to 4.6.4

### DIFF
--- a/denny-zipline/docker-compose.yml
+++ b/denny-zipline/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     environment:
       APP_HOST: denny-zipline_web_1
       APP_PORT: 3000
-      PROXY_AUTH_ADD: "false"
+      PROXY_AUTH_ADD: 'false'
 
   db:
     image: postgres:17.3@sha256:6e3358e46e34dae6c184f48fd06fe1b3dbf958ad5b83480031907e52b9ec2a7d
@@ -15,23 +15,35 @@ services:
       POSTGRES_DB: zipline
       POSTGRES_USER: ziplineuser
       POSTGRES_PASSWORD: ziplinepass
+    healthcheck:
+      test: ['CMD', 'pg_isready', '-d', 'zipline', '-U', 'ziplineuser']
+      interval: 10s
+      timeout: 5s
+      retries: 5
     restart: on-failure
 
   web:
-    image: ghcr.io/diced/zipline:4.0.0@sha256:73351d7b653b2362895004398609adcfc60b2b7c9ad50b7cb488c8f4c36d4b3a
+    image: ghcr.io/diced/zipline:4.6.4@sha256:3e3a57520e0bdf614b74676c4fe0f14c430215b6f659133ce108edc54a167a8c
     environment:
       DATABASE_URL: postgresql://ziplineuser:ziplinepass@db:5432/zipline?schema=public
       CORE_SECRET: 3b449077187f1150082fb348796e97be22b57fefdbd4a7b18f575b51f65519b7
       CORE_PORT: 3000
       CORE_HOSTNAME: 0.0.0.0
       DATASOURCE_TYPE: local
-      DATASOURCE_LOCAL_DIRECTORY: /data/files 
+      DATASOURCE_LOCAL_DIRECTORY: /data/files
     volumes:
       - ./data/uploads:/zipline/uploads:rw
       - ./data/public:/zipline/public:rw
       - ./data/themes:/zipline/themes:rw
+    depends_on:
+      - db
+    healthcheck:
+      test: ['CMD', 'wget', '-q', '--spider', 'http://localhost:3000/api/healthcheck']
+      interval: 15s
+      timeout: 2s
+      retries: 2
     logging:
       options:
-        max-size: "10m"
-        max-file: "3"
+        max-size: '10m'
+        max-file: '3'
     restart: on-failure

--- a/denny-zipline/umbrel-app.yml
+++ b/denny-zipline/umbrel-app.yml
@@ -4,7 +4,7 @@ name: Zipline
 tagline: An advanced solution for seamless and secure file sharing
 icon: https://raw.githubusercontent.com/dennysubke/dennys-umbrel-app-gallery/main/denny-zipline/logo.png
 category: files & productivity
-version: "4.0.0"
+version: "4.6.4"
 port: 3472
 description: >-
   Zipline is an open-source, self-hosted file-sharing and upload server designed primarily for use with ShareX but also supports other upload methods. It allows users to upload and share files, screenshots, and text snippets via a custom domain while maintaining control over their data.
@@ -21,7 +21,7 @@ description: >-
 
   By offering a private, efficient, and highly customizable solution, Zipline ensures full control over uploaded data, making it an ideal alternative to centralized services.
 developer: diced
-website: https://www.mumble.info/
+website: https://zipline.diced.sh/
 submitter: dennysubke
 submission: https://github.com/getumbrel/umbrel-apps/pull/
 repo: https://github.com/diced/zipline
@@ -31,7 +31,12 @@ gallery:
   - https://raw.githubusercontent.com/dennysubke/dennys-umbrel-app-gallery/main/denny-zipline/2.jpg
   - https://raw.githubusercontent.com/dennysubke/dennys-umbrel-app-gallery/main/denny-zipline/3.jpg
 releaseNotes: >-
-  Zipline v4.0.0 is a major update released after over two years of development. It features a revamped API, a new invitation system, improved file and user management, and numerous UI enhancements in the dashboard. Additionally, it introduces features like password-protected URLs, OIDC support, a new CLI tool, and improved upload options, while v3 will continue receiving critical bug fixes and security updates.
+  This update includes:
+    - Enhanced File Management: Introduced nested folders, a new full-screen file viewer with keyboard navigation, and batch uploading for up to 500 files.
+    - Advanced Security & Access: Implemented PKCE for OIDC OAuth, a 15-minute access token system for password-protected files, and a more robust, OpenAPI 3.x compatible API.
+    - Admin & Performance Tools: Added a new admin dashboard with system activity charts and significantly optimized the loading speed for large datasets and file counts.
+
+  Full release notes can be found at https://github.com/diced/zipline/releases
 dependencies:
 path: ""
 defaultUsername: ""


### PR DESCRIPTION
Updated Zipline to 4.6.4, added healthcheck (see for [db ](https://github.com/diced/zipline/blob/57ab8deacbad71562bbf6e20da24e3078e5a8c16/docker-compose.yml#L13)& [service](https://github.com/diced/zipline/blob/57ab8deacbad71562bbf6e20da24e3078e5a8c16/docker-compose.yml#L35)) and small fix.

Tested on my Raspberry Pi 5 with Umbrel OS 1.5 and nettop with Umbrel 1.7.3, all fine.