### PR TITLE
Update Airstation to 1.4.1

### DIFF
--- a/denny-airstation/docker-compose.yml
+++ b/denny-airstation/docker-compose.yml
@@ -7,11 +7,17 @@ services:
       APP_PORT: 7331
 
   web:
-    image: cheatsnake/airstation:1.0.0-beta.4@sha256:1201c88b3ca8982b4237473c0e2c438d7224585657eb64a72690f3549b982b1c
+    image: cheatsnake/airstation:1.4.1@sha256:03914d06060e10b12045fee6080fba5838aafe528abeef8e5907ccfb2bbfafb2
     restart: on-failure
     environment:
       AIRSTATION_SECRET_KEY: dOxZYTTZgXKMHkqLBIQVImayQXAVWdzGBPuFJKggzcgvgPJPXpWzqzKaUOIOGGIr
       AIRSTATION_JWT_SIGN: LWpPZTOilFGAxBHoaTRqRPAEKXpVLUTUCodRDSRpMDCkxFdAyCIiVhkXaKHZwEBc
+    healthcheck:
+      test: ['CMD', 'wget', '-q', '--spider', 'http://localhost:7331']
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
     volumes:
       - ${APP_DATA_DIR}/data/airstation_data:/app/storage:rw
       - ${APP_DATA_DIR}/data/airstation_static:/app/static:rw

--- a/denny-airstation/umbrel-app.yml
+++ b/denny-airstation/umbrel-app.yml
@@ -4,7 +4,7 @@ name: Airstation
 tagline: An instant radio station
 icon: https://raw.githubusercontent.com/dennysubke/dennys-umbrel-app-gallery/main/denny-airstation/logo.png
 category: media
-version: "1.0.0"
+version: "1.4.1"
 port: 7331
 description: >-
   📻 Airstation is an open-source, self-hosted web application designed to allow users to create and manage their own online radio station. It provides an intuitive and minimalist interface for streaming music over the internet, making it easy for anyone to broadcast their favorite tracks to listeners worldwide. The platform enables users to upload audio files, organize playlists, and control playback through a simple web-based player that listeners can access from any device.
@@ -28,7 +28,16 @@ gallery:
   - https://raw.githubusercontent.com/dennysubke/dennys-umbrel-app-gallery/main/denny-airstation/2.jpg
   - https://raw.githubusercontent.com/dennysubke/dennys-umbrel-app-gallery/main/denny-airstation/3.jpg
 releaseNotes: >-
-  The update adds an extra authentication check to improve security and fixes the caching scope issue in the PWA for better performance. Additionally, it refactors the database file path for clarity and removes unnecessary arguments from the multi-architecture CI setup.
+  This release includes new features & enhancements:
+
+    - Player page customization: added support for themes and hot reloading of station information (including themes) on the player page.
+    - Station management: introduced support for custom station information, including name, description, logo, favicon, and links.
+    - Media support: expanded audio format compatibility to include WAV and FLAC files.
+    - Track & queue management: implemented playlist support for improved track management and enhanced drag-and-drop functionality for the queue.
+    - Studio interface: added settings to customize the interface width of the studio.
+
+
+  Full release notes can be found at https://github.com/cheatsnake/airstation/releases
 dependencies:
 path: "/studio"
 defaultUsername: ""


### PR DESCRIPTION
Updated Airstation to 1.4.1 and added healthcheck.

Tested on my Raspberry Pi 5 with Umbrel OS 1.5 and nettop with Umbrel OS 1.7.3.